### PR TITLE
adding patch for restoring correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,40 @@ public function cascadable() : array  {
 }
 ```
 
+## Cascade Restore only those deleted by cascade delete
+Normally, when running a cascade restore after a cascade delete, all child models would be restored, regardless if they were in trashed state prior to the cascade delete.  This patch fixes that.  
+
+### Configurations Added
+There are 2 configurations added to the config:
+
+- enable_mapping_child_delete_to_parent_delete (boolean, default: true)
+  - enable/disable this feature
+- model_delete_mapping_col (string, default: deletedByCascade)
+  - the column name in each model table used for mapping
+
+### Migrations required
+Basically, each model that has the below trait will need a column added.   
+```php
+use HasSoftCascade;
+```
+Your migration should add this to each model:
+```php
+$table->boolean(config('soft-cascade.model_delete_mapping_col'))
+      ->default(false);
+```
+
+Also add the column name to each of the model $fillable property, like so:
+```php
+    protected $fillable = [
+        'album_id',
+        'deletedByCascade'
+    ];
+```
+
+However, there is a caveat.  There's always going to be that model that is last in the cascade.  This model won't have the trait HasSoftCascade in the model, however, should be using SoftDelete trait.  This final model needs the column in the database table as well.  
+
+See the example models in the ***example-models*** folder
+
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/config/soft-cascade.php
+++ b/config/soft-cascade.php
@@ -61,4 +61,29 @@ return [
     |
     */
 	'force_delete_on_model_force_delete' => true,
+
+	/*
+    |-----------------------------------------------------------------------------
+    | Should cascade delete keep track of cascaded models deleted at time of parent delete
+    |-----------------------------------------------------------------------------
+    | If a model alredy has child records soft deleted and that model is deleted via this package,
+    | then all child models will be sodt deleted with no true method to determine, during restore, 
+    | if the child was part of parent soft delete or not.  Enabling this config and adding column to any/all
+    | child models will solve this issue.
+    |
+    */
+	'enable_mapping_child_delete_to_parent_delete' => true,	
+	
+	/*
+    |-----------------------------------------------------------------------------
+    | Column in model to map child delete to parent delete
+    |-----------------------------------------------------------------------------
+    | If enable_mapping_child_delete_to_parent_delete is true, this column needs to be
+    | in the model as defined below in a migration
+    |
+    |
+    |   $table->softDeletes();
+    |   $table->boolean('deletedByCascade')->default(false);
+    */
+	'model_delete_mapping_col' => 'deletedByCascade',	
 ];

--- a/example-models/Album.php
+++ b/example-models/Album.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Touhidurabir\ModelSoftCascade\HasSoftCascade;
+
+class Album extends Model
+{
+    use HasFactory, SoftDeletes, HasSoftCascade;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'deletedByCascade'
+    ];
+
+    public function cascadable() : array {
+
+        return [
+            'media'
+        ];
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function media()
+    {
+        return $this->hasMany(Media::class);
+    }
+}

--- a/example-models/Media.php
+++ b/example-models/Media.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Media extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'album_id',
+        'deletedByCascade'
+    ];
+
+    public function album()
+    {
+        return $this->belongsTo(Album::class);
+    }
+}

--- a/example-models/User.php
+++ b/example-models/User.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Models;
+
+use Touhidurabir\ModelSoftCascade\HasSoftCascade;
+use Illuminate\Cache\HasCacheLock;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Fortify\TwoFactorAuthenticatable;
+use Laravel\Jetstream\HasProfilePhoto;
+use Laravel\Sanctum\HasApiTokens;
+
+class User extends Authenticatable
+{
+    use HasApiTokens;
+    use HasFactory;
+    use HasProfilePhoto;
+    use Notifiable;
+    use TwoFactorAuthenticatable;
+    use SoftDeletes;
+    use HasSoftCascade;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var string[]
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'deletedByCascade'
+    ];
+
+    public function cascadable() : array {
+
+        return [
+            'albums'
+        ];
+    }
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+        'two_factor_recovery_codes',
+        'two_factor_secret',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'email_verified_at' => 'datetime'
+    ];
+
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = [
+        'profile_photo_url',
+    ];
+
+    public function albums()
+    {
+        return $this->hasMany(Album::class);
+    }
+}

--- a/src/Concerns/SoftCascadeDelete.php
+++ b/src/Concerns/SoftCascadeDelete.php
@@ -88,6 +88,9 @@ trait SoftCascadeDelete {
 
 						if ( $modelRel instanceof Model ) {
 
+							if ($this->mapCascadedParentDeleteToChildDelete) {
+								$modelRel->update([$this->mapModelCol => true]);
+							}
 							$modelRel->{$deleteMethod}();	
 						}
 					}
@@ -97,6 +100,9 @@ trait SoftCascadeDelete {
 
 				if ( $modelRels instanceof Model ) {
 
+					if ($this->mapCascadedParentDeleteToChildDelete) {
+						$modelRels->update([$this->mapModelCol => true]);
+					}
 					$modelRels->{$deleteMethod}();
 				}
 			}

--- a/src/Concerns/SoftCascadeRestore.php
+++ b/src/Concerns/SoftCascadeRestore.php
@@ -65,7 +65,15 @@ trait SoftCascadeRestore {
 
 				foreach ($modelRels as $modelRel) {
 					
-					! ($modelRel instanceof Model) ?: $modelRel->restore();
+					if ($this->mapCascadedParentDeleteToChildDelete) {
+						!($modelRel instanceof Model) ?: $isUpdatedByCascade = $modelRel->getAttribute($this->mapModelCol);
+						if ($isUpdatedByCascade) {
+							!($modelRel instanceof Model) ?: $modelRel->restore();
+							!($modelRel instanceof Model) ?: $modelRel->update([$this->mapModelCol => false]);
+						}
+					} else {
+						!($modelRel instanceof Model) ?: $modelRel->restore();
+					}
 				}
 				
 				// $model->{$restoreRelation}()->withTrashed()->restore();

--- a/src/HasSoftCascade.php
+++ b/src/HasSoftCascade.php
@@ -30,6 +30,20 @@ trait HasSoftCascade {
      */
     protected $runAsDatabaseTransaction = true;
 
+    /**
+     * Should map the child delete as deleted by cascade
+     *
+     * @var bool
+     */
+    protected $mapCascadedParentDeleteToChildDelete = true;
+
+    /**
+     * The column in the model table used for mapping if 
+     * $this->mapCascadedParentDeleteToChildDelete = true
+     *
+     * @var string
+     */
+    protected $mapModelCol = 'deletedByCascade';
 
     /**
      * The abstract cascade configuration method
@@ -102,6 +116,8 @@ trait HasSoftCascade {
         $this->restoreEvent = $configs['restore']['event']  ?? config('soft-cascade.events.restore') ?? 'restoring';
 
         $this->runAsDatabaseTransaction = config('soft-cascade.on_database_transaction') ?? true;
+        $this->mapCascadedParentDeleteToChildDelete = config('enable_mapping_child_delete_to_parent_delete') ?? true;
+        $this->mapModelCol = config('model_delete_mapping_col') ?? 'deletedByCascade';
     }
 
 


### PR DESCRIPTION
I wanted to add to this to enhance it by making sure the restore would only restore the models deleted by the cascade delete.  This has been talked about if many other packages and online, so I figured this was an easy enough patch to this package.  I have tested in a dev environment with tons of models and it does work.  